### PR TITLE
feat: Save bases from the start of the at-bat

### DIFF
--- a/server.js
+++ b/server.js
@@ -336,7 +336,8 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
             pitcherAction: null,
             batterAction: null,
             pitchRollResult: null,
-            swingRollResult: null
+            swingRollResult: null,
+            basesBeforePlay: { first: null, second: null, third: null }
         }
       };
 
@@ -1054,7 +1055,7 @@ app.post('/api/games/:gameId/next-hitter', authenticateToken, async (req, res) =
     if (!originalState.homePlayerReadyForNext && !originalState.awayPlayerReadyForNext) {
       // 1. Save the completed at-bat for the other player to see.
       newState.lastCompletedAtBat = { ...newState.currentAtBat,
-        bases: newState.bases, // Save the bases as they were after the play
+        bases: newState.currentAtBat.basesBeforePlay,
         eventCount: newState.currentAtBat.swingRollResult?.eventCount || 1, // Save the event count
         outs: newState.outs 
        };
@@ -1070,9 +1071,10 @@ app.post('/api/games/:gameId/next-hitter', authenticateToken, async (req, res) =
       const { batter, pitcher } = await getActivePlayers(gameId, newState);
       newState.currentAtBat = {
           batter: batter,
-      pitcher: pitcher,
-      pitcherAction: null, batterAction: null,
-      pitchRollResult: null, swingRollResult: null
+          pitcher: pitcher,
+          pitcherAction: null, batterAction: null,
+          pitchRollResult: null, swingRollResult: null,
+          basesBeforePlay: newState.bases
       };
     }
 


### PR DESCRIPTION
To correctly display the base state when a play's outcome is hidden, the `lastCompletedAtBat` object must store the bases as they were at the beginning of the at-bat.

This change introduces a `basesBeforePlay` field to the `currentAtBat` object, which captures a snapshot of the bases when a new at-bat begins. When the at-bat is completed, this field is used to populate the `bases` property of the `lastCompletedAtBat` object.